### PR TITLE
JWT refresh token and logout

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,41 @@
+Review the staged changes and create a git commit.
+
+## Rules
+
+**Before committing:**
+- Run `swift test` and confirm all tests pass. If tests fail, stop and report the failures.
+
+**Commit message format:**
+- Use conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`
+- Subject line: max 72 chars, imperative mood ("add", "fix", "remove" — not "added" or "adds")
+- Write like a developer wrote it — natural, direct, no AI/tool references
+- No "Co-Authored-By" lines, no "Generated with" footers, nothing that signals automated tooling
+- If changes are non-trivial, add a short body (1–3 lines) explaining the *why*, not the *what*
+
+**Examples of good messages:**
+```
+feat: add JWT expiration validation to auth payload
+fix: normalize color codes to always include # prefix
+refactor: extract category validation into separate method
+test: cover duplicate category name edge case
+```
+
+**Examples to avoid:**
+```
+feat: Added new feature as requested          ← past tense
+chore: update files                           ← vague
+feat: implement X                             ← no context when non-obvious
+Co-Authored-By: Claude ...                    ← AI attribution
+```
+
+## Steps
+
+1. Run `git diff --staged` to review staged changes
+2. Run `swift test` — stop if any test fails
+3. Check if docs need updating based on the changes:
+   - **CLAUDE.md** — new commands, architecture changes, new patterns or conventions introduced
+   - **README.md** — new endpoints, changed setup steps, new dependencies. Write naturally as a developer would: no multiple emojis, no AI-sounding structure, no generated footers
+   - **`.claude/commands/`** — new review rules if new patterns were added
+   If any need updates, make them and stage them before committing.
+4. Draft commit message following the rules above
+5. Show me the message and ask for confirmation before running `git commit`

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,40 @@
+Review the current changes (staged + unstaged) or a specified file for correctness, Vapor patterns, and Swift 6 compliance.
+
+## Review Checklist
+
+### Swift 6 / Concurrency
+- [ ] Types crossing actor boundaries conform to `@Sendable`
+- [ ] No data races — mutable state is properly isolated
+- [ ] Async functions use `async throws` correctly, not nested callbacks
+
+### Vapor Patterns
+- [ ] New DTOs from `GrowBitSharedDTO` have `@retroactive Content` conformance in `Extensions/`
+- [ ] New models have a corresponding migration registered in `configure.swift`
+- [ ] Routes are registered via `RouteCollection`, not inline in `configure.swift`
+- [ ] HTTP status codes match intent: 400 (bad input), 401 (wrong credentials), 404 (not found), 409 (conflict), 422 (validation), 500 (unexpected)
+
+### Models & Database
+- [ ] New `Model` fields have matching migration columns
+- [ ] Parent/child relationships use `@Parent` / `@Children` Fluent property wrappers
+- [ ] No raw SQL — use Fluent query builder
+
+### Auth
+- [ ] Endpoints that require ownership check the `:userId` param against the token's `uid`
+- [ ] JWT secret is never hardcoded (only fallback in `.testing` environment is acceptable)
+
+### Error Handling
+- [ ] Errors are thrown as `Abort(.statusCode, reason: "...")` — no silent swallows
+- [ ] Validation errors surface as 422, not 500
+
+### Tests
+- [ ] New endpoints have corresponding tests in `Tests/GrowBitAppServerTests/`
+- [ ] Tests use `withApp` helper and do not share state between cases
+
+## Output Format
+
+Report findings as:
+- **Critical** — correctness bugs, security issues, missing auth checks
+- **Warning** — pattern violations, missing tests
+- **Suggestion** — optional improvements
+
+Skip sections with no findings. Be direct — one line per issue with the file and relevant line reference.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ default.profraw
 .vscode
 Package.resolved
 
-# Development guidance for Claude Code
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Run the server
+swift run GrowBitAppServer serve --hostname 0.0.0.0 --port 8080
+
+# Run all tests
+swift test
+
+# Run a single test suite
+swift test --filter GrowBitAppServerLoginTests
+
+# Docker
+docker compose build
+docker compose up app
+docker compose down
+```
+
+## Architecture
+
+**Vapor 4** REST API for habit tracking. Swift 6.2, async/await throughout.
+
+### Key Dependencies
+- **Fluent** (ORM) with PostgreSQL (prod) / SQLite in-memory (testing)
+- **JWTKit** — HMAC-SHA256 tokens; requires `JWT_SECRET` env var
+- **GrowBitSharedDTO** — external package (`dmakarau/GrowBitSharedDTO`) with shared request/response types
+
+### Request/Response Types
+Auth response types (`AuthResponseDTO`, `RefreshResponseDTO`, `LogoutResponseDTO`) are local structs in `Sources/GrowBitAppServer/DTOs/`. Other shared DTOs live in the external `GrowBitSharedDTO` package and get Vapor `Content` conformance via `@retroactive` extensions in `Sources/GrowBitAppServer/Extensions/`.
+
+### Route Structure
+Routes are registered as `RouteCollection` objects in `configure.swift`:
+- `UserController` → `POST /api/register`, `POST /api/login`, `POST /api/refresh`, `POST /api/logout`
+- `HabitsController` → `POST|GET|DELETE /api/:userId/categories` — JWT protected via `JWTAuthMiddleware`
+
+### Database
+- `configure.swift` switches on `app.environment`: SQLite in-memory for `.testing`, PostgreSQL (`localhost:5432/habitstrackerdb`) otherwise
+- Migrations run automatically in test environment; must be registered manually in `configure.swift` when adding new models
+
+### Auth
+- **Access token**: JWT (`AuthPayload` with `uid` + `exp`), signed HMAC-SHA256, expires in 15 minutes
+- **Refresh token**: opaque UUID stored in `refresh_tokens` table, expires in 7 days
+- Login returns `AuthResponseDTO` with both `token` and `refreshToken`
+- `POST /api/refresh` accepts `{ refreshToken }` in body, returns new access token
+- `POST /api/logout` accepts `{ refreshToken }` in body, deletes the DB row (idempotent)
+- `JWTAuthMiddleware` verifies the Bearer token and checks `pathUserId == payload.userId` — prevents cross-user access
+
+### Testing Pattern
+All tests use Vapor's `withApp` helper + Apple's `@Suite`/`@Test` macros. Each test creates its own in-memory DB state — no shared fixtures. Category tests use a `registerAndLogin` helper to obtain a Bearer token for `Authorization` headers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Routes are registered as `RouteCollection` objects in `configure.swift`:
 - Migrations run automatically in test environment; must be registered manually in `configure.swift` when adding new models
 
 ### Auth
-- **Access token**: JWT (`AuthPayload` with `uid` + `exp`), signed HMAC-SHA256, expires in 15 minutes
+- **Access token**: JWT (`AuthPayload` with `uid`, `exp`, `jti`), signed HMAC-SHA256, expires in 15 minutes; `jti` is a random UUID ensuring every token is unique
 - **Refresh token**: opaque UUID stored in `refresh_tokens` table, expires in 7 days
 - Login returns `AuthResponseDTO` with both `token` and `refreshToken`
 - `POST /api/refresh` accepts `{ refreshToken }` in body, returns new access token
@@ -50,4 +50,4 @@ Routes are registered as `RouteCollection` objects in `configure.swift`:
 - `JWTAuthMiddleware` verifies the Bearer token and checks `pathUserId == payload.userId` — prevents cross-user access
 
 ### Testing Pattern
-All tests use Vapor's `withApp` helper + Apple's `@Suite`/`@Test` macros. Each test creates its own in-memory DB state — no shared fixtures. Category tests use a `registerAndLogin` helper to obtain a Bearer token for `Authorization` headers.
+All tests use Vapor's `withApp` helper + Apple's `@Suite`/`@Test` macros. Each test creates its own in-memory DB state — no shared fixtures. Shared test utilities live in `Tests/GrowBitAppServerTests/TestHelpers.swift` — `registerAndLogin(in:username:)` and `TestError`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,11 @@ Routes are registered as `RouteCollection` objects in `configure.swift`:
 
 ### Auth
 - **Access token**: JWT (`AuthPayload` with `uid`, `exp`, `jti`), signed HMAC-SHA256, expires in 15 minutes; `jti` is a random UUID ensuring every token is unique
-- **Refresh token**: opaque UUID stored in `refresh_tokens` table, expires in 7 days
+- **Refresh token**: random UUID, stored as SHA-256 hash in `refresh_tokens` table, expires in 7 days; raw token returned to client once and never stored
 - Login returns `AuthResponseDTO` with both `token` and `refreshToken`
-- `POST /api/refresh` accepts `{ refreshToken }` in body, returns new access token
+- `POST /api/refresh` accepts `{ refreshToken }` in body, rotates the token (deletes old, issues new), returns new access token + new refresh token via `RefreshResponseDTO`
 - `POST /api/logout` accepts `{ refreshToken }` in body, deletes the DB row (idempotent)
+- On login, expired tokens for the user are pruned automatically
 - `JWTAuthMiddleware` verifies the Bearer token and checks `pathUserId == payload.userId` — prevents cross-user access
 
 ### Testing Pattern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,10 @@ Routes are registered as `RouteCollection` objects in `configure.swift`:
 - **Access token**: JWT (`AuthPayload` with `uid`, `exp`, `jti`), signed HMAC-SHA256, expires in 15 minutes; `jti` is a random UUID ensuring every token is unique
 - **Refresh token**: random UUID, stored as SHA-256 hash in `refresh_tokens` table, expires in 7 days; raw token returned to client once and never stored
 - Login returns `AuthResponseDTO` with both `token` and `refreshToken`
-- `POST /api/refresh` accepts `{ refreshToken }` in body, rotates the token (deletes old, issues new), returns new access token + new refresh token via `RefreshResponseDTO`
+- `POST /api/refresh` accepts `{ refreshToken }` in body, rotates the token (deletes old, issues new) atomically inside a `req.db.transaction`, returns new access token + new refresh token via `RefreshResponseDTO`
 - `POST /api/logout` accepts `{ refreshToken }` in body, deletes the DB row (idempotent)
 - On login, expired tokens for the user are pruned automatically
+- `refresh_tokens` has indexes on `user_id` and `(user_id, expires_at)` — added via raw `SQLKit` SQL in the migration because Fluent's `SchemaBuilder` does not support non-unique indexes
 - `JWTAuthMiddleware` verifies the Bearer token and checks `pathUserId == payload.userId` — prevents cross-user access
 
 ### Testing Pattern

--- a/README.md
+++ b/README.md
@@ -6,38 +6,37 @@ A Swift-based REST API server for habit tracking, built with the Vapor web frame
 
 - **Framework**: Vapor 4 (Swift server-side framework)
 - **ORM**: Fluent
-- **Authentication**: JWT
+- **Authentication**: JWT (access tokens) + DB-backed refresh tokens
 - **Databases**:
   - PostgreSQL (production)
-  - SQLite (development)
+  - SQLite in-memory (testing)
 - **Swift Version**: 6.2+
 - **Platform**: macOS 13+
 - **Shared DTOs**: GrowBitSharedDTO (external package)
 
 ## Features
 
-- Secure JWT authentication
-- Protected API routes
-- User registration and management
-- Habit and category CRUD operations
-- RESTful API design
+- User registration and login
+- JWT authentication with refresh token support
+- Protected API routes with cross-user access enforcement
+- Category management (create, list, delete)
 
 ## API Endpoints
 
-### Implemented Endpoints
+### Implemented
 
 #### Authentication
-- `POST /api/register` - User registration ✅
-- `POST /api/login` - Returns access token (15 min) and refresh token (7 days) ✅
-- `POST /api/refresh` - Issue new access token from a valid refresh token ✅
-- `POST /api/logout` - Revoke refresh token ✅
+- `POST /api/register` - Register a new user
+- `POST /api/login` - Returns access token (15 min) and refresh token (7 days)
+- `POST /api/refresh` - Issue new access token from a valid refresh token
+- `POST /api/logout` - Revoke refresh token
 
 #### Categories (JWT protected)
-- `POST /api/:userId/categories` - Create new category ✅
-- `GET /api/:userId/categories` - Get all categories for user ✅
-- `DELETE /api/:userId/categories/:categoryId` - Delete category ✅
+- `POST /api/:userId/categories` - Create new category
+- `GET /api/:userId/categories` - Get all categories for user
+- `DELETE /api/:userId/categories/:categoryId` - Delete category
 
-### Planned Endpoints
+### Planned
 
 #### Categories
 - `PUT /api/:userId/categories/:id` - Update category
@@ -57,9 +56,9 @@ A Swift-based REST API server for habit tracking, built with the Vapor web frame
 
 ### Prerequisites
 
-- Swift 6.2+ installed on your system
+- Swift 6.2+
 - Xcode (for macOS development)
-- Docker (optional, for containerized deployment)
+- Docker (optional)
 
 ### Installation
 
@@ -74,39 +73,32 @@ cd GrowBit-API-Server
 swift package resolve
 ```
 
-3. Set up environment variables (create `.env` file):
+3. Create a `.env` file:
 ```bash
-DATABASE_URL=your_database_url_here
 JWT_SECRET=your_jwt_secret_here
 ```
 
-**Important**: Generate a secure JWT secret using:
+Generate a secure secret with:
 ```bash
 openssl rand -base64 32
 ```
 
 ### Running the Server
 
-#### Development Mode
 ```bash
 swift run GrowBitAppServer serve --hostname 0.0.0.0 --port 8080
 ```
 
-#### Using Docker
+#### Docker
+
 ```bash
-# Build the image
 docker compose build
-
-# Start the server
 docker compose up app
-
-# Stop all services
 docker compose down
 ```
 
 ### Testing
 
-Run the test suite:
 ```bash
 swift test
 ```
@@ -115,102 +107,61 @@ swift test
 
 ```
 GrowBit-API-Server/
-├── Package.swift                 # Swift Package Manager configuration
+├── Package.swift
 ├── Sources/
 │   └── GrowBitAppServer/
-│       ├── entrypoint.swift      # Application entry point
-│       ├── configure.swift       # Application configuration
-│       ├── routes.swift          # Route definitions
-│       ├── Controllers/          # API controllers
-│       │   ├── UserController.swift # User registration/auth controller
-│       │   └── HabitsController.swift # Habits and categories controller
-│       ├── Models/               # Data models
-│       │   ├── User.swift        # User model with validation
-│       │   ├── Category.swift    # Category model
-│       │   └── AuthPayload.swift # JWT payload structure
-│       ├── Extensions/           # Protocol conformances for shared types
-│       │   ├── RegisterResponseDTO+Extensions.swift # Vapor Content conformance
-│       │   ├── LoginResponseDTO+Extensions.swift    # Vapor Content conformance
-│       │   └── CategoryResponseDTO+Extensions.swift # Category DTO conformance
-│       └── Migrations/           # Database migrations
+│       ├── entrypoint.swift
+│       ├── configure.swift
+│       ├── routes.swift
+│       ├── Controllers/
+│       │   ├── UserController.swift
+│       │   └── HabitsController.swift
+│       ├── Models/
+│       │   ├── User.swift
+│       │   ├── Category.swift
+│       │   ├── RefreshToken.swift
+│       │   ├── AuthPayload.swift
+│       │   └── TokenExpiry.swift
+│       ├── DTOs/
+│       │   ├── AuthResponseDTO.swift
+│       │   ├── RefreshResponseDTO.swift
+│       │   └── LogoutResponseDTO.swift
+│       ├── Middleware/
+│       │   └── JWTAuthMiddleware.swift
+│       ├── Extensions/
+│       └── Migrations/
 │           ├── CreateUsersTableMigration.swift
-│           └── CreateHabitsCategoryTableMigration.swift
+│           ├── CreateHabitsCategoryTableMigration.swift
+│           └── CreateRefreshTokensTableMigration.swift
 ├── Tests/
 │   └── GrowBitAppServerTests/
-│       ├── GrowBitAppServerTests.swift
-│       └── GrowBitAppServerLoginTests.swift
-├── Public/                       # Static files directory
-├── Dockerfile                    # Docker configuration
-├── docker-compose.yml           # Docker Compose configuration
-└── README.md                    # This file
+├── Dockerfile
+├── docker-compose.yml
+└── CLAUDE.md
 ```
 
-## Environment Configuration
+## Environment Variables
 
-Create a `.env` file in the root directory with the following variables:
-
-```bash
-# Database Configuration
-DATABASE_URL=postgresql://username:password@localhost:5432/growbit_db
-
-# JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-here
-
-# Server Configuration (optional)
-LOG_LEVEL=debug
-```
-
-## Deployment
-
-### Heroku Deployment
-
-This application is configured for deployment on Heroku with PostgreSQL:
-
-1. Create a new Heroku app
-2. Add Heroku Postgres addon
-3. Set environment variables in Heroku dashboard
-4. Deploy using Git or GitHub integration
-
-### Docker Deployment
-
-The included Dockerfile provides a production-ready container:
-
-```bash
-docker build -t habit-tracker-api .
-docker run -p 8080:8080 habit-tracker-api
-```
+| Variable | Required | Description |
+|---|---|---|
+| `JWT_SECRET` | Yes | Secret key for signing JWT tokens |
 
 ## Development Status
 
 This project serves as a learning experience for backend development with Vapor.
 
-### Current Implementation
-- ✅ Basic Vapor server setup with routing infrastructure
-- ✅ User model with Fluent ORM integration
-- ✅ User registration endpoint with validation
-- ✅ User login endpoint with JWT token generation
-- ✅ Password hashing and verification
-- ✅ Database migration for users table
-- ✅ Category model with database migration
-- ✅ Categories CRUD operations (Create, Read, Delete)
-- ✅ Category validation (color code format, empty names, duplicate names)
-- ✅ Color code normalization (RRGGBB format with # prefix)
-- ✅ User ownership verification for category operations
-- ✅ Swift 6.2 concurrency support (@Sendable)
-- ✅ Shared DTO package integration with @retroactive conformance
-- ✅ JWT refresh token with DB-backed revocation
-- ✅ Logout endpoint (revokes refresh token, idempotent)
-- ✅ Protected category routes via JWT middleware (cross-user access blocked)
-- ✅ Test suite for all endpoints including refresh and logout
+### Implemented
+- User registration and login with bcrypt password hashing
+- JWT access tokens (15 min) + DB-backed refresh tokens (7 days)
+- Token refresh and logout with revocation
+- Category CRUD (create, read, delete) with validation
+- JWT middleware protecting category routes
+- Full test coverage for all endpoints
 
-### Planned Features
-- Category UPDATE operation
-- Habits CRUD operations
-- Habit entries and calendar functionality
-
-## Contributing
-
-This is a learning project. Feel free to explore the code and suggest improvements.
+### Planned
+- Category update endpoint
+- Habits CRUD
+- Habit entries and calendar view
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A Swift-based REST API server for habit tracking, built with the Vapor web frame
 #### Authentication
 - `POST /api/register` - Register a new user
 - `POST /api/login` - Returns access token (15 min) and refresh token (7 days)
-- `POST /api/refresh` - Issue new access token from a valid refresh token
+- `POST /api/refresh` - Issue new access and refresh tokens (rotates the refresh token)
 - `POST /api/logout` - Revoke refresh token
 
 #### Categories (JWT protected)

--- a/README.md
+++ b/README.md
@@ -28,18 +28,16 @@ A Swift-based REST API server for habit tracking, built with the Vapor web frame
 
 #### Authentication
 - `POST /api/register` - User registration ✅
-- `POST /api/login` - User login ✅
+- `POST /api/login` - Returns access token (15 min) and refresh token (7 days) ✅
+- `POST /api/refresh` - Issue new access token from a valid refresh token ✅
+- `POST /api/logout` - Revoke refresh token ✅
 
-#### Categories
+#### Categories (JWT protected)
 - `POST /api/:userId/categories` - Create new category ✅
 - `GET /api/:userId/categories` - Get all categories for user ✅
 - `DELETE /api/:userId/categories/:categoryId` - Delete category ✅
 
 ### Planned Endpoints
-
-#### Authentication
-- `POST /api/refresh` - Refresh JWT token
-- `POST /api/logout` - User logout
 
 #### Categories
 - `PUT /api/:userId/categories/:id` - Update category
@@ -200,19 +198,15 @@ This project serves as a learning experience for backend development with Vapor.
 - ✅ User ownership verification for category operations
 - ✅ Swift 6.2 concurrency support (@Sendable)
 - ✅ Shared DTO package integration with @retroactive conformance
-- ✅ Test suite for authentication endpoints
-- ✅ Test suite for category operations (create, fetch, delete)
-- ✅ Comprehensive error handling with proper HTTP status codes
-
-### In Progress
-- 🔄 User logout endpoint
-- 🔄 Protected routes with JWT middleware
+- ✅ JWT refresh token with DB-backed revocation
+- ✅ Logout endpoint (revokes refresh token, idempotent)
+- ✅ Protected category routes via JWT middleware (cross-user access blocked)
+- ✅ Test suite for all endpoints including refresh and logout
 
 ### Planned Features
-- 📋 Category UPDATE operation
-- 📋 Habits CRUD operations
-- 📋 Habit entries and calendar functionality
-- 📋 JWT token refresh endpoint
+- Category UPDATE operation
+- Habits CRUD operations
+- Habit entries and calendar functionality
 
 ## Contributing
 

--- a/Sources/GrowBitAppServer/Controllers/HabitsController.swift
+++ b/Sources/GrowBitAppServer/Controllers/HabitsController.swift
@@ -12,17 +12,18 @@ import GrowBitSharedDTO
 struct HabitsController: RouteCollection {
     func boot(routes: any RoutesBuilder) throws {
         
-        // /api/:userId
+        // /api/:userId — JWT protected
         let api = routes.grouped("api", ":userId")
-        
+            .grouped(JWTAuthMiddleware())
+
         // POST: saving a habbit category
         // /api/:userId/categories
         api.post("categories", use: saveHabitCategory)
-        
+
         // GET: getting all categories for a user
         // /api/:userId/categories
         api.get("categories", use: getAllCategoriesForUser)
-        
+
         // DELETE: deleting a category
         // /api/:userId/categories/:categoryId
         api.delete("categories", ":categoryId", use: deleteCategory)

--- a/Sources/GrowBitAppServer/Controllers/UserController.swift
+++ b/Sources/GrowBitAppServer/Controllers/UserController.swift
@@ -37,14 +37,14 @@ struct UserController: RouteCollection {
         let userId = try existingUser.requireID()
 
         let authPayload = AuthPayload(
-            expiration: .init(value: Date().addingTimeInterval(60 * 15)),
+            expiration: .init(value: Date().addingTimeInterval(TokenExpiry.access)),
             userId: userId
         )
         let accessToken = try await req.jwt.sign(authPayload)
 
         let refreshToken = RefreshToken(
             userId: userId,
-            expiresAt: Date().addingTimeInterval(60 * 60 * 24 * 7)
+            expiresAt: Date().addingTimeInterval(TokenExpiry.refresh)
         )
         try await refreshToken.save(on: req.db)
 
@@ -56,14 +56,10 @@ struct UserController: RouteCollection {
     }
 
     @Sendable func refresh(req: Request) async throws -> RefreshResponseDTO {
-        struct RefreshRequest: Content {
-            let refreshToken: String
-        }
         let body = try req.content.decode(RefreshRequest.self)
 
         guard let storedToken = try await RefreshToken.query(on: req.db)
             .filter(\.$token == body.refreshToken)
-            .with(\.$user)
             .first()
         else {
             throw Abort(.unauthorized, reason: "Invalid refresh token")
@@ -75,7 +71,7 @@ struct UserController: RouteCollection {
         }
 
         let authPayload = AuthPayload(
-            expiration: .init(value: Date().addingTimeInterval(60 * 15)),
+            expiration: .init(value: Date().addingTimeInterval(TokenExpiry.access)),
             userId: storedToken.$user.id
         )
         let accessToken = try await req.jwt.sign(authPayload)
@@ -84,9 +80,6 @@ struct UserController: RouteCollection {
     }
 
     @Sendable func logout(req: Request) async throws -> LogoutResponseDTO {
-        struct LogoutRequest: Content {
-            let refreshToken: String
-        }
         let body = try req.content.decode(LogoutRequest.self)
 
         if let storedToken = try await RefreshToken.query(on: req.db)
@@ -117,4 +110,14 @@ struct UserController: RouteCollection {
 
         return RegisterResponseDTO(error: false)
     }
+}
+
+// MARK: - Request Bodies
+
+private struct RefreshRequest: Content {
+    let refreshToken: String
+}
+
+private struct LogoutRequest: Content {
+    let refreshToken: String
 }

--- a/Sources/GrowBitAppServer/Controllers/UserController.swift
+++ b/Sources/GrowBitAppServer/Controllers/UserController.swift
@@ -36,6 +36,12 @@ struct UserController: RouteCollection {
 
         let userId = try existingUser.requireID()
 
+        // Prune expired tokens for this user before issuing a new one
+        try await RefreshToken.query(on: req.db)
+            .filter(\.$user.$id == userId)
+            .filter(\.$expiresAt < Date())
+            .delete()
+
         let authPayload = AuthPayload(
             expiration: .init(value: Date().addingTimeInterval(TokenExpiry.access)),
             userId: userId
@@ -50,7 +56,7 @@ struct UserController: RouteCollection {
 
         return AuthResponseDTO(
             token: accessToken,
-            refreshToken: refreshToken.token,
+            refreshToken: refreshToken.rawToken,
             userId: userId
         )
     }
@@ -58,8 +64,9 @@ struct UserController: RouteCollection {
     @Sendable func refresh(req: Request) async throws -> RefreshResponseDTO {
         let body = try req.content.decode(RefreshRequest.self)
 
+        let tokenHash = RefreshToken.hash(body.refreshToken)
         guard let storedToken = try await RefreshToken.query(on: req.db)
-            .filter(\.$token == body.refreshToken)
+            .filter(\.$token == tokenHash)
             .first()
         else {
             throw Abort(.unauthorized, reason: "Invalid refresh token")
@@ -70,20 +77,29 @@ struct UserController: RouteCollection {
             throw Abort(.unauthorized, reason: "Refresh token has expired")
         }
 
+        // Rotate: invalidate used token, issue a new one
+        try await storedToken.delete(on: req.db)
+        let newRefreshToken = RefreshToken(
+            userId: storedToken.$user.id,
+            expiresAt: Date().addingTimeInterval(TokenExpiry.refresh)
+        )
+        try await newRefreshToken.save(on: req.db)
+
         let authPayload = AuthPayload(
             expiration: .init(value: Date().addingTimeInterval(TokenExpiry.access)),
             userId: storedToken.$user.id
         )
         let accessToken = try await req.jwt.sign(authPayload)
 
-        return RefreshResponseDTO(token: accessToken)
+        return RefreshResponseDTO(token: accessToken, refreshToken: newRefreshToken.rawToken)
     }
 
     @Sendable func logout(req: Request) async throws -> LogoutResponseDTO {
         let body = try req.content.decode(LogoutRequest.self)
 
+        let tokenHash = RefreshToken.hash(body.refreshToken)
         if let storedToken = try await RefreshToken.query(on: req.db)
-            .filter(\.$token == body.refreshToken)
+            .filter(\.$token == tokenHash)
             .first() {
             try await storedToken.delete(on: req.db)
         }

--- a/Sources/GrowBitAppServer/Controllers/UserController.swift
+++ b/Sources/GrowBitAppServer/Controllers/UserController.swift
@@ -26,12 +26,12 @@ struct UserController: RouteCollection {
         guard let existingUser = try await User.query(on: req.db)
             .filter(\.$username == user.username)
             .first() else {
-                throw Abort(.badRequest, reason: "User not found")
+                throw Abort(.unauthorized, reason: "Invalid credentials")
             }
 
         let passwordMatch = try await req.password.async.verify(user.password, created: existingUser.password)
         if !passwordMatch {
-            throw Abort(.unauthorized, reason: "Wrong password")
+            throw Abort(.unauthorized, reason: "Invalid credentials")
         }
 
         let userId = try existingUser.requireID()

--- a/Sources/GrowBitAppServer/Controllers/UserController.swift
+++ b/Sources/GrowBitAppServer/Controllers/UserController.swift
@@ -65,29 +65,32 @@ struct UserController: RouteCollection {
         let body = try req.content.decode(RefreshRequest.self)
 
         let tokenHash = RefreshToken.hash(body.refreshToken)
-        guard let storedToken = try await RefreshToken.query(on: req.db)
-            .filter(\.$token == tokenHash)
-            .first()
-        else {
-            throw Abort(.unauthorized, reason: "Invalid refresh token")
-        }
 
-        guard storedToken.expiresAt > Date() else {
-            try await storedToken.delete(on: req.db)
-            throw Abort(.unauthorized, reason: "Refresh token has expired")
-        }
+        let (newRefreshToken, userId) = try await req.db.transaction { db in
+            guard let storedToken = try await RefreshToken.query(on: db)
+                .filter(\.$token == tokenHash)
+                .first()
+            else {
+                throw Abort(.unauthorized, reason: "Invalid refresh token")
+            }
 
-        // Rotate: invalidate used token, issue a new one
-        try await storedToken.delete(on: req.db)
-        let newRefreshToken = RefreshToken(
-            userId: storedToken.$user.id,
-            expiresAt: Date().addingTimeInterval(TokenExpiry.refresh)
-        )
-        try await newRefreshToken.save(on: req.db)
+            guard storedToken.expiresAt > Date() else {
+                try await storedToken.delete(on: db)
+                throw Abort(.unauthorized, reason: "Refresh token has expired")
+            }
+
+            try await storedToken.delete(on: db)
+            let newToken = RefreshToken(
+                userId: storedToken.$user.id,
+                expiresAt: Date().addingTimeInterval(TokenExpiry.refresh)
+            )
+            try await newToken.save(on: db)
+            return (newToken, storedToken.$user.id)
+        }
 
         let authPayload = AuthPayload(
             expiration: .init(value: Date().addingTimeInterval(TokenExpiry.access)),
-            userId: storedToken.$user.id
+            userId: userId
         )
         let accessToken = try await req.jwt.sign(authPayload)
 

--- a/Sources/GrowBitAppServer/Controllers/UserController.swift
+++ b/Sources/GrowBitAppServer/Controllers/UserController.swift
@@ -14,44 +14,94 @@ struct UserController: RouteCollection {
     func boot(routes: any Vapor.RoutesBuilder) throws {
         let api = routes.grouped("api")
 
-        // /api/register
         api.post("register", use: register)
-        
-        // /api/login
         api.post("login", use: login)
+        api.post("refresh", use: refresh)
+        api.post("logout", use: logout)
     }
-    
-    @Sendable func login(req: Request) async throws ->  LoginResponseDTO {
-        
-        // decode the request
+
+    @Sendable func login(req: Request) async throws -> AuthResponseDTO {
         let user = try req.content.decode(User.self)
-        
-        // check if the user is in DB
+
         guard let existingUser = try await User.query(on: req.db)
             .filter(\.$username == user.username)
             .first() else {
                 throw Abort(.badRequest, reason: "User not found")
             }
-        
-        // check the password
-        let result = try await req.password.async.verify(user.password, created: existingUser.password)
-        if !result {
+
+        let passwordMatch = try await req.password.async.verify(user.password, created: existingUser.password)
+        if !passwordMatch {
             throw Abort(.unauthorized, reason: "Wrong password")
         }
-        
-        // generate the token and return it to the user
-        let authPayload = try AuthPayload(
-            expiration: .init(value: .distantFuture),
-            userId: existingUser.requireID()
+
+        let userId = try existingUser.requireID()
+
+        let authPayload = AuthPayload(
+            expiration: .init(value: Date().addingTimeInterval(60 * 15)),
+            userId: userId
         )
-        return try await LoginResponseDTO(error: false, token: req.jwt.sign(authPayload), userId: existingUser.requireID())
+        let accessToken = try await req.jwt.sign(authPayload)
+
+        let refreshToken = RefreshToken(
+            userId: userId,
+            expiresAt: Date().addingTimeInterval(60 * 60 * 24 * 7)
+        )
+        try await refreshToken.save(on: req.db)
+
+        return AuthResponseDTO(
+            token: accessToken,
+            refreshToken: refreshToken.token,
+            userId: userId
+        )
+    }
+
+    @Sendable func refresh(req: Request) async throws -> RefreshResponseDTO {
+        struct RefreshRequest: Content {
+            let refreshToken: String
+        }
+        let body = try req.content.decode(RefreshRequest.self)
+
+        guard let storedToken = try await RefreshToken.query(on: req.db)
+            .filter(\.$token == body.refreshToken)
+            .with(\.$user)
+            .first()
+        else {
+            throw Abort(.unauthorized, reason: "Invalid refresh token")
+        }
+
+        guard storedToken.expiresAt > Date() else {
+            try await storedToken.delete(on: req.db)
+            throw Abort(.unauthorized, reason: "Refresh token has expired")
+        }
+
+        let authPayload = AuthPayload(
+            expiration: .init(value: Date().addingTimeInterval(60 * 15)),
+            userId: storedToken.$user.id
+        )
+        let accessToken = try await req.jwt.sign(authPayload)
+
+        return RefreshResponseDTO(token: accessToken)
+    }
+
+    @Sendable func logout(req: Request) async throws -> LogoutResponseDTO {
+        struct LogoutRequest: Content {
+            let refreshToken: String
+        }
+        let body = try req.content.decode(LogoutRequest.self)
+
+        if let storedToken = try await RefreshToken.query(on: req.db)
+            .filter(\.$token == body.refreshToken)
+            .first() {
+            try await storedToken.delete(on: req.db)
+        }
+
+        return LogoutResponseDTO(message: "Logged out successfully")
     }
 
     @Sendable func register(req: Request) async throws -> RegisterResponseDTO {
         do {
             try User.validate(content: req)
         } catch let error as ValidationsError {
-            // 422 Unprocessable Entity for validation failures
             throw Abort(.unprocessableEntity, reason: error.description)
         }
 
@@ -59,17 +109,12 @@ struct UserController: RouteCollection {
         if let _ = try await User.query(on: req.db)
             .filter(\.$username == user.username)
             .first() {
-            // 409 Conflict for username already taken
             throw Abort(.conflict, reason: "Username is already taken")
         }
-        
-        // hash the password
+
         user.password = try await req.password.async.hash(user.password)
-        
-        // save the user into the database
         try await user.save(on: req.db)
-        
-        // find if the user exists
+
         return RegisterResponseDTO(error: false)
     }
 }

--- a/Sources/GrowBitAppServer/DTOs/AuthResponseDTO.swift
+++ b/Sources/GrowBitAppServer/DTOs/AuthResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  AuthResponseDTO.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+import Vapor
+
+struct AuthResponseDTO: Content {
+    let token: String
+    let refreshToken: String
+    let userId: UUID
+}

--- a/Sources/GrowBitAppServer/DTOs/LogoutResponseDTO.swift
+++ b/Sources/GrowBitAppServer/DTOs/LogoutResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  LogoutResponseDTO.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+import Vapor
+
+struct LogoutResponseDTO: Content {
+    let message: String
+}

--- a/Sources/GrowBitAppServer/DTOs/RefreshResponseDTO.swift
+++ b/Sources/GrowBitAppServer/DTOs/RefreshResponseDTO.swift
@@ -1,0 +1,11 @@
+//
+//  RefreshResponseDTO.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+import Vapor
+
+struct RefreshResponseDTO: Content {
+    let token: String
+}

--- a/Sources/GrowBitAppServer/DTOs/RefreshResponseDTO.swift
+++ b/Sources/GrowBitAppServer/DTOs/RefreshResponseDTO.swift
@@ -8,4 +8,5 @@ import Vapor
 
 struct RefreshResponseDTO: Content {
     let token: String
+    let refreshToken: String
 }

--- a/Sources/GrowBitAppServer/Middleware/JWTAuthMiddleware.swift
+++ b/Sources/GrowBitAppServer/Middleware/JWTAuthMiddleware.swift
@@ -1,0 +1,20 @@
+//
+//  JWTAuthMiddleware.swift
+//  GrowBitAppServer
+//
+
+import Vapor
+
+struct JWTAuthMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let payload = try await request.jwt.verify(as: AuthPayload.self)
+
+        if let userIdString = request.parameters.get("userId"),
+           let pathUserId = UUID(uuidString: userIdString),
+           pathUserId != payload.userId {
+            throw Abort(.forbidden, reason: "Access denied")
+        }
+
+        return try await next.respond(to: request)
+    }
+}

--- a/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
+++ b/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
@@ -3,7 +3,6 @@
 //  GrowBitAppServer
 //
 
-import Foundation
 import Fluent
 
 struct CreateRefreshTokensTableMigration: AsyncMigration {

--- a/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
+++ b/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
@@ -1,0 +1,24 @@
+//
+//  CreateRefreshTokensTableMigration.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+import Fluent
+
+struct CreateRefreshTokensTableMigration: AsyncMigration {
+
+    func prepare(on database: any Database) async throws {
+        try await database.schema("refresh_tokens")
+            .id()
+            .field("token", .string, .required)
+            .field("user_id", .uuid, .required, .references("users", "id", onDelete: .cascade))
+            .field("expires_at", .datetime, .required)
+            .unique(on: "token")
+            .create()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema("refresh_tokens").delete()
+    }
+}

--- a/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
+++ b/Sources/GrowBitAppServer/Migrations/CreateRefreshTokensTableMigration.swift
@@ -4,6 +4,7 @@
 //
 
 import Fluent
+import SQLKit
 
 struct CreateRefreshTokensTableMigration: AsyncMigration {
 
@@ -15,6 +16,11 @@ struct CreateRefreshTokensTableMigration: AsyncMigration {
             .field("expires_at", .datetime, .required)
             .unique(on: "token")
             .create()
+
+        if let sql = database as? any SQLDatabase {
+            try await sql.raw("CREATE INDEX idx_rt_user_id ON refresh_tokens (user_id)").run()
+            try await sql.raw("CREATE INDEX idx_rt_user_expires ON refresh_tokens (user_id, expires_at)").run()
+        }
     }
 
     func revert(on database: any Database) async throws {

--- a/Sources/GrowBitAppServer/Models/AuthPayload.swift
+++ b/Sources/GrowBitAppServer/Models/AuthPayload.swift
@@ -9,21 +9,26 @@ import Foundation
 import JWT
 
 struct AuthPayload: JWTPayload {
-    
+
     typealias Payload = AuthPayload
-    
+
     enum CodingKeys: String, CodingKey {
         case expiration = "exp"
         case userId = "uid"
+        case tokenId = "jti"
     }
-    
+
     var expiration: ExpirationClaim
     var userId: UUID
-    
-    
+    var tokenId: UUID
+
+    init(expiration: ExpirationClaim, userId: UUID) {
+        self.expiration = expiration
+        self.userId = userId
+        self.tokenId = UUID()
+    }
+
     func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {
         try self.expiration.verifyNotExpired()
     }
-    
-    
 }

--- a/Sources/GrowBitAppServer/Models/RefreshToken.swift
+++ b/Sources/GrowBitAppServer/Models/RefreshToken.swift
@@ -5,7 +5,6 @@
 
 import Foundation
 import Fluent
-import Vapor
 
 final class RefreshToken: Model, @unchecked Sendable {
     static let schema = "refresh_tokens"

--- a/Sources/GrowBitAppServer/Models/RefreshToken.swift
+++ b/Sources/GrowBitAppServer/Models/RefreshToken.swift
@@ -3,6 +3,7 @@
 //  GrowBitAppServer
 //
 
+import CryptoKit
 import Foundation
 import Fluent
 
@@ -21,11 +22,21 @@ final class RefreshToken: Model, @unchecked Sendable {
     @Field(key: "expires_at")
     var expiresAt: Date
 
+    // Transient — holds the raw token after creation, never persisted
+    var rawToken: String = ""
+
+    static func hash(_ raw: String) -> String {
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
     init() {}
 
     init(id: UUID? = nil, userId: UUID, expiresAt: Date) {
+        let raw = UUID().uuidString
         self.id = id
-        self.token = UUID().uuidString
+        self.rawToken = raw
+        self.token = RefreshToken.hash(raw)
         self.$user.id = userId
         self.expiresAt = expiresAt
     }

--- a/Sources/GrowBitAppServer/Models/RefreshToken.swift
+++ b/Sources/GrowBitAppServer/Models/RefreshToken.swift
@@ -1,0 +1,33 @@
+//
+//  RefreshToken.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+import Fluent
+import Vapor
+
+final class RefreshToken: Model, @unchecked Sendable {
+    static let schema = "refresh_tokens"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "token")
+    var token: String
+
+    @Parent(key: "user_id")
+    var user: User
+
+    @Field(key: "expires_at")
+    var expiresAt: Date
+
+    init() {}
+
+    init(id: UUID? = nil, userId: UUID, expiresAt: Date) {
+        self.id = id
+        self.token = UUID().uuidString
+        self.$user.id = userId
+        self.expiresAt = expiresAt
+    }
+}

--- a/Sources/GrowBitAppServer/Models/RefreshToken.swift
+++ b/Sources/GrowBitAppServer/Models/RefreshToken.swift
@@ -3,9 +3,9 @@
 //  GrowBitAppServer
 //
 
-import CryptoKit
 import Foundation
 import Fluent
+import Vapor
 
 final class RefreshToken: Model, @unchecked Sendable {
     static let schema = "refresh_tokens"
@@ -26,8 +26,7 @@ final class RefreshToken: Model, @unchecked Sendable {
     var rawToken: String = ""
 
     static func hash(_ raw: String) -> String {
-        let digest = SHA256.hash(data: Data(raw.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
+        SHA256.hash(data: Data(raw.utf8)).hex
     }
 
     init() {}

--- a/Sources/GrowBitAppServer/Models/TokenExpiry.swift
+++ b/Sources/GrowBitAppServer/Models/TokenExpiry.swift
@@ -1,0 +1,11 @@
+//
+//  TokenExpiry.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+
+enum TokenExpiry {
+    static let access: TimeInterval = 60 * 15           // 15 minutes
+    static let refresh: TimeInterval = 60 * 60 * 24 * 7 // 7 days
+}

--- a/Sources/GrowBitAppServer/configure.swift
+++ b/Sources/GrowBitAppServer/configure.swift
@@ -31,6 +31,7 @@ public func configure(_ app: Application) async throws {
     
     app.migrations.add(CreateUsersTableMigration())
     app.migrations.add(CreateHabitsCategoryTableMigration())
+    app.migrations.add(CreateRefreshTokensTableMigration())
 
     // Auto-migrate in testing environment (creates tables automatically)
     if app.environment == .testing {

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
@@ -14,33 +14,35 @@ import Fluent
 @Suite("Category Deletion Tests")
 struct GrowBitAppServerDeleteCategoryTests {
 
+    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
+        let user = User(username: username, password: "password")
+        try await app.testing().test(.POST, "/api/register") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+        }
+
+        var token = ""
+        var userId = UUID()
+        try await app.testing().test(.POST, "/api/login") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            let response = try res.content.decode(AuthResponseDTO.self)
+            token = response.token
+            userId = response.userId
+        }
+        return (token, userId)
+    }
+
     @Test("Delete category - Success")
     func deleteCategorySuccess() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "deleteuser1", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "deleteuser1")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser1")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create a category
-            let categoryRequestBody = [
-                "name": "Test Category",
-                "colorCode": "#FF0000"
-            ]
-
+            let categoryRequestBody = ["name": "Test Category", "colorCode": "#FF0000"]
             var categoryId: UUID?
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(categoryRequestBody)
             } afterResponse: { res in
                 #expect(res.status == .ok)
@@ -53,9 +55,8 @@ struct GrowBitAppServerDeleteCategoryTests {
                 throw TestError.userCreationFailed
             }
 
-            // Delete the category
             try await app.testing().test(.DELETE, "/api/\(userId.uuidString)/categories/\(unwrappedCategoryId.uuidString)") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode(CategoryResponseDTO.self)
@@ -64,7 +65,6 @@ struct GrowBitAppServerDeleteCategoryTests {
                 #expect(response.colorCode == "#FF0000")
             }
 
-            // Verify the category was actually deleted from the database
             let deletedCategory = try await Category.query(on: app.db)
                 .filter(\.$id == unwrappedCategoryId)
                 .first()
@@ -75,23 +75,8 @@ struct GrowBitAppServerDeleteCategoryTests {
     @Test("Delete category - Verify category is removed from list")
     func deleteCategoryVerifyRemoval() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "deleteuser2", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "deleteuser2")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser2")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create multiple categories
             let categories = [
                 ["name": "Work", "colorCode": "#FF0000"],
                 ["name": "Personal", "colorCode": "#00FF00"],
@@ -101,6 +86,7 @@ struct GrowBitAppServerDeleteCategoryTests {
             var categoryIds: [UUID] = []
             for category in categories {
                 try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                     try req.content.encode(category)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
@@ -111,60 +97,40 @@ struct GrowBitAppServerDeleteCategoryTests {
 
             #expect(categoryIds.count == 3)
 
-            // Delete the category
             try await app.testing().test(.DELETE, "/api/\(userId.uuidString)/categories/\(categoryIds[1].uuidString)") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode(CategoryResponseDTO.self)
-                #expect(response.id == (categoryIds[1]))
+                #expect(response.id == categoryIds[1])
                 #expect(response.name == "Personal")
                 #expect(response.colorCode == "#00FF00")
             }
-            
-            // Verify the category was actually deleted from the database
+
             let deletedCategory = try await Category.query(on: app.db)
                 .filter(\.$id == categoryIds[1])
                 .first()
             #expect(deletedCategory == nil)
-            
-            // Verify the category still exists for user1
+
             var category = try await Category.query(on: app.db)
                 .filter(\.$id == categoryIds[0])
                 .first()
             #expect(category != nil)
-            
-            // Verify the third category still exists for user1
+
             category = try await Category.query(on: app.db)
                 .filter(\.$id == categoryIds[2])
                 .first()
             #expect(category != nil)
         }
-        
     }
 
     @Test("Delete category - Fail - Invalid categoryId")
     func deleteCategoryInvalidCategoryId() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "deleteuser3", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "deleteuser3")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser3")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Try to delete with invalid category UUID format
             try await app.testing().test(.DELETE, "/api/\(userId.uuidString)/categories/invalid-uuid") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
             }
@@ -174,26 +140,11 @@ struct GrowBitAppServerDeleteCategoryTests {
     @Test("Delete category - Fail - Non-existent categoryId")
     func deleteCategoryNonExistentCategoryId() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "deleteuser4", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "deleteuser4")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser4")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Try to delete a category that doesn't exist (valid UUID format but doesn't exist)
             let nonExistentId = UUID()
             try await app.testing().test(.DELETE, "/api/\(userId.uuidString)/categories/\(nonExistentId.uuidString)") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .notFound)
                 #expect(res.body.string.contains("Category not found"))
@@ -204,29 +155,12 @@ struct GrowBitAppServerDeleteCategoryTests {
     @Test("Delete category - Fail - Invalid userId")
     func deleteCategoryInvalidUserId() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user and category
-            let userRequestBody = User(username: "deleteuser5", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "deleteuser5")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser5")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create a category
-            let categoryRequestBody = [
-                "name": "Test Category",
-                "colorCode": "#FF0000"
-            ]
-
+            let categoryRequestBody = ["name": "Test Category", "colorCode": "#FF0000"]
             var categoryId: UUID?
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(categoryRequestBody)
             } afterResponse: { res in
                 #expect(res.status == .ok)
@@ -238,9 +172,8 @@ struct GrowBitAppServerDeleteCategoryTests {
                 throw TestError.userCreationFailed
             }
 
-            // Try to delete with invalid user UUID format
             try await app.testing().test(.DELETE, "/api/invalid-uuid/categories/\(unwrappedCategoryId.uuidString)") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
             }
@@ -250,44 +183,13 @@ struct GrowBitAppServerDeleteCategoryTests {
     @Test("Delete category - User isolation test")
     func deleteCategoryUserIsolation() async throws {
         try await withApp(configure: configure) { app in
-            // Create two users
-            let userRequestBody1 = User(username: "deleteuser6a", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody1)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token1, userId1) = try await registerAndLogin(in: app, username: "deleteuser6a")
+            let (token2, userId2) = try await registerAndLogin(in: app, username: "deleteuser6b")
 
-            let userRequestBody2 = User(username: "deleteuser6b", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody2)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
-
-            // Retrieve both users
-            guard let createdUser1 = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser6a")
-                .first(),
-                  let userId1 = createdUser1.id else {
-                throw TestError.userCreationFailed
-            }
-
-            guard let createdUser2 = try await User.query(on: app.db)
-                .filter(\.$username == "deleteuser6b")
-                .first(),
-                  let userId2 = createdUser2.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create a category for user1
-            let categoryRequestBody = [
-                "name": "User1 Category",
-                "colorCode": "#FF0000"
-            ]
-
+            let categoryRequestBody = ["name": "User1 Category", "colorCode": "#FF0000"]
             var user1CategoryId: UUID?
             try await app.testing().test(.POST, "/api/\(userId1.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token1)
                 try req.content.encode(categoryRequestBody)
             } afterResponse: { res in
                 #expect(res.status == .ok)
@@ -299,15 +201,14 @@ struct GrowBitAppServerDeleteCategoryTests {
                 throw TestError.userCreationFailed
             }
 
-            // Try to delete user1's category using user2's userId
+            // user2 tries to delete user1's category via user2's path — not found (belongs to user1)
             try await app.testing().test(.DELETE, "/api/\(userId2.uuidString)/categories/\(unwrappedUser1CategoryId.uuidString)") { req in
-                // No body needed for DELETE request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token2)
             } afterResponse: { res in
                 #expect(res.status == .notFound)
                 #expect(res.body.string.contains("Category not found"))
             }
 
-            // Verify the category still exists for user1
             let category = try await Category.query(on: app.db)
                 .filter(\.$id == unwrappedUser1CategoryId)
                 .filter(\.$user.$id == userId1)

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
@@ -14,26 +14,6 @@ import Fluent
 @Suite("Category Deletion Tests")
 struct GrowBitAppServerDeleteCategoryTests {
 
-    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
-        let user = User(username: username, password: "password")
-        try await app.testing().test(.POST, "/api/register") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            #expect(res.status == .ok)
-        }
-
-        var token = ""
-        var userId = UUID()
-        try await app.testing().test(.POST, "/api/login") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            let response = try res.content.decode(AuthResponseDTO.self)
-            token = response.token
-            userId = response.userId
-        }
-        return (token, userId)
-    }
-
     @Test("Delete category - Success")
     func deleteCategorySuccess() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerDeleteCategoryTests.swift
@@ -160,6 +160,20 @@ struct GrowBitAppServerDeleteCategoryTests {
         }
     }
 
+    @Test("Delete category - Fail - Cross-user access returns 403")
+    func deleteCategoryCrossUserForbidden() async throws {
+        try await withApp(configure: configure) { app in
+            let (tokenA, _)  = try await registerAndLogin(in: app, username: "delxuser_a")
+            let (_, userBId) = try await registerAndLogin(in: app, username: "delxuser_b")
+
+            try await app.testing().test(.DELETE, "/api/\(userBId.uuidString)/categories/\(UUID().uuidString)") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: tokenA)
+            } afterResponse: { res in
+                #expect(res.status == .forbidden)
+            }
+        }
+    }
+
     @Test("Delete category - User isolation test")
     func deleteCategoryUserIsolation() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
@@ -14,26 +14,6 @@ import Fluent
 @Suite("Category Fetching Tests")
 struct GrowBitAppServerFetchingCategoriesTests {
 
-    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
-        let user = User(username: username, password: "password")
-        try await app.testing().test(.POST, "/api/register") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            #expect(res.status == .ok)
-        }
-
-        var token = ""
-        var userId = UUID()
-        try await app.testing().test(.POST, "/api/login") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            let response = try res.content.decode(AuthResponseDTO.self)
-            token = response.token
-            userId = response.userId
-        }
-        return (token, userId)
-    }
-
     @Test("Fetch all categories - Success with multiple categories")
     func fetchAllCategoriesSuccess() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
@@ -141,6 +141,20 @@ struct GrowBitAppServerFetchingCategoriesTests {
         }
     }
 
+    @Test("Fetch all categories - Fail - Cross-user access returns 403")
+    func fetchCategoriesCrossUserForbidden() async throws {
+        try await withApp(configure: configure) { app in
+            let (tokenA, _)  = try await registerAndLogin(in: app, username: "crossuser_a")
+            let (_, userBId) = try await registerAndLogin(in: app, username: "crossuser_b")
+
+            try await app.testing().test(.GET, "/api/\(userBId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: tokenA)
+            } afterResponse: { res in
+                #expect(res.status == .forbidden)
+            }
+        }
+    }
+
     @Test("Fetch all categories - Verify color normalization persistence")
     func fetchAllCategoriesColorNormalization() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerFetchingCategoriesTests.swift
@@ -14,55 +14,57 @@ import Fluent
 @Suite("Category Fetching Tests")
 struct GrowBitAppServerFetchingCategoriesTests {
 
+    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
+        let user = User(username: username, password: "password")
+        try await app.testing().test(.POST, "/api/register") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+        }
+
+        var token = ""
+        var userId = UUID()
+        try await app.testing().test(.POST, "/api/login") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            let response = try res.content.decode(AuthResponseDTO.self)
+            token = response.token
+            userId = response.userId
+        }
+        return (token, userId)
+    }
+
     @Test("Fetch all categories - Success with multiple categories")
     func fetchAllCategoriesSuccess() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "fetchuser1", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "fetchuser1")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "fetchuser1")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create multiple categories
             let categories = [
                 ["name": "Work", "colorCode": "#FF0000"],
                 ["name": "Personal", "colorCode": "#00FF00"],
                 ["name": "Health", "colorCode": "#0000FF"]
             ]
-
             for category in categories {
                 try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                     try req.content.encode(category)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
                 }
             }
 
-            // Fetch all categories
             try await app.testing().test(.GET, "/api/\(userId.uuidString)/categories") { req in
-                // No body needed for GET request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode([CategoryResponseDTO].self)
                 #expect(response.count == 3)
 
-                // Verify category names
                 let categoryNames = response.map { $0.name }
                 #expect(categoryNames.contains("Work"))
                 #expect(categoryNames.contains("Personal"))
                 #expect(categoryNames.contains("Health"))
 
-                // Verify all categories have valid IDs and color codes
                 for category in response {
                     #expect(category.id != nil)
                     #expect(category.colorCode.hasPrefix("#"))
@@ -74,25 +76,10 @@ struct GrowBitAppServerFetchingCategoriesTests {
     @Test("Fetch all categories - Success with empty result")
     func fetchAllCategoriesEmptyResult() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "fetchuser2", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "fetchuser2")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "fetchuser2")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Fetch categories without creating any
             try await app.testing().test(.GET, "/api/\(userId.uuidString)/categories") { req in
-                // No body needed for GET request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode([CategoryResponseDTO].self)
@@ -104,9 +91,10 @@ struct GrowBitAppServerFetchingCategoriesTests {
     @Test("Fetch all categories - Fail - Invalid userId")
     func fetchAllCategoriesInvalidUserId() async throws {
         try await withApp(configure: configure) { app in
-            // Try to fetch categories with invalid UUID
+            let (token, _) = try await registerAndLogin(in: app, username: "fetchuser_invalidid")
+
             try await app.testing().test(.GET, "/api/invalid-uuid/categories") { req in
-                // No body needed for GET request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
             }
@@ -116,145 +104,90 @@ struct GrowBitAppServerFetchingCategoriesTests {
     @Test("Fetch all categories - User isolation test")
     func fetchAllCategoriesUserIsolation() async throws {
         try await withApp(configure: configure) { app in
-            
-            // Create two users
-            
-            let userRequestBody1 = User(username: "fetchuser3a", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody1)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
-            let userRequestBody2 = User(username: "fetchuser3b", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody2)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
-            // Retrieve the created users
-            guard let createdUser1 = try await User.query(on: app.db)
-                .filter(\.$username == "fetchuser3a")
-                .first(),
-                  let userId1 = createdUser1.id else {
-                throw TestError.userCreationFailed
-            }
-            guard let createdUser2 = try await User.query(on: app.db)
-                .filter(\.$username == "fetchuser3b")
-                .first(),
-                  let userId2 = createdUser2.id else {
-                throw TestError.userCreationFailed
-            }
-            
-            // Create categories for user1
+            let (token1, userId1) = try await registerAndLogin(in: app, username: "fetchuser3a")
+            let (token2, userId2) = try await registerAndLogin(in: app, username: "fetchuser3b")
+
             let categories1 = [
                 ["name": "Work", "colorCode": "#FF0000"],
                 ["name": "Personal", "colorCode": "#00FF00"],
                 ["name": "Health", "colorCode": "#0000FF"]
             ]
-            
             for category in categories1 {
                 try await app.testing().test(.POST, "/api/\(userId1.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token1)
                     try req.content.encode(category)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
                 }
             }
-            
-            // Create categories for user2
-            
+
             let categories2 = [
                 ["name": "Fitness", "colorCode": "#FFFF00"],
                 ["name": "Hobbies", "colorCode": "#FF00FF"]
             ]
-            
             for category in categories2 {
                 try await app.testing().test(.POST, "/api/\(userId2.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token2)
                     try req.content.encode(category)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
                 }
             }
-            
-            // Fetch categories for user1 and verify only user1's categories are returned
-            
+
             try await app.testing().test(.GET, "/api/\(userId1.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token1)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode([CategoryResponseDTO].self)
                 #expect(response.count == 3)
-                
-                // Verify category names
                 let categoryNames = response.map { $0.name }
                 #expect(categoryNames.contains("Work"))
                 #expect(categoryNames.contains("Personal"))
                 #expect(categoryNames.contains("Health"))
                 #expect(!categoryNames.contains("Fitness"))
             }
-            
-            // Fetch categories for user2 and verify only user2's categories are returned
-            
+
             try await app.testing().test(.GET, "/api/\(userId2.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token2)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode([CategoryResponseDTO].self)
                 #expect(response.count == 2)
-                
-                // Verify category names
                 let categoryNames = response.map { $0.name }
                 #expect(!categoryNames.contains("Work"))
-                #expect(!categoryNames.contains("Personal"))
                 #expect(categoryNames.contains("Hobbies"))
                 #expect(categoryNames.contains("Fitness"))
             }
         }
-
     }
 
     @Test("Fetch all categories - Verify color normalization persistence")
     func fetchAllCategoriesColorNormalization() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "fetchuser4", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "fetchuser4")
 
-            // Retrieve the created user
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "fetchuser4")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create categories with and without # prefix
             let categoriesWithColors = [
-                ["name": "Cat1", "colorCode": "FF0000"],    // Without #
-                ["name": "Cat2", "colorCode": "#00FF00"]    // With #
+                ["name": "Cat1", "colorCode": "FF0000"],
+                ["name": "Cat2", "colorCode": "#00FF00"]
             ]
-
             for category in categoriesWithColors {
                 try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                     try req.content.encode(category)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
                 }
             }
 
-            // Fetch all categories and verify normalization
             try await app.testing().test(.GET, "/api/\(userId.uuidString)/categories") { req in
-                // No body needed for GET request
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode([CategoryResponseDTO].self)
                 #expect(response.count == 2)
-
-                // All color codes should have # prefix after normalization
                 for category in response {
                     #expect(category.colorCode.hasPrefix("#"))
-                    #expect(category.colorCode.count == 7) // # + 6 hex characters
+                    #expect(category.colorCode.count == 7)
                 }
             }
         }

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
@@ -61,51 +61,41 @@ struct GrowBitAppServerLoginTests {
             try await app.testing().test(.POST, "/api/login") { req in
                 try req.content.encode(loginCredentials)
             } afterResponse: { res in
-                #expect(res.status == .badRequest)
-                // Check that we get a meaningful error response (not empty)
+                #expect(res.status == .unauthorized)
                 #expect(!res.body.string.isEmpty)
-                #expect(res.body.string.contains("User not found"))
-
+                #expect(res.body.string.contains("Invalid credentials"))
             }
         }
     }
-    
+
     @Test("Test User Login Fail - Wrong password")
     func testUserLoginFailureWrongPassword() async throws {
         try await withApp(configure: configure) { app in
-            // Create user in this app instance
             try await createUser(in: app)
 
-            // Now test login with the same app instance
             let loginCredentials = User(username: "testuser", password: "wrongpassword")
             try await app.testing().test(.POST, "/api/login") { req in
                 try req.content.encode(loginCredentials)
             } afterResponse: { res in
                 #expect(res.status == .unauthorized)
-                // Check that we get a meaningful error response (not empty)
                 #expect(!res.body.string.isEmpty)
-                #expect(res.body.string.contains("Wrong password"))
-
+                #expect(res.body.string.contains("Invalid credentials"))
             }
         }
     }
-    
+
     @Test("Test User Login Fail - Wrong username and wrong password")
     func testUserLoginFailureWrongUsernameAndWrongPassword() async throws {
         try await withApp(configure: configure) { app in
-            // Create user in this app instance
             try await createUser(in: app)
 
-            // Now test login with the same app instance
             let loginCredentials = User(username: "wronguser", password: "wrongpassword")
             try await app.testing().test(.POST, "/api/login") { req in
                 try req.content.encode(loginCredentials)
             } afterResponse: { res in
-                #expect(res.status == .badRequest)
-                // Check that we get a meaningful error response (not empty)
+                #expect(res.status == .unauthorized)
                 #expect(!res.body.string.isEmpty)
-                #expect(res.body.string.contains("User not found"))
-
+                #expect(res.body.string.contains("Invalid credentials"))
             }
         }
     }

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
@@ -10,6 +10,7 @@ import Foundation
 import GrowBitSharedDTO
 import VaporTesting
 import Testing
+import Fluent
 
 @Suite("App Login Tests")
 struct GrowBitAppServerLoginTests {
@@ -27,20 +28,24 @@ struct GrowBitAppServerLoginTests {
     @Test("Test User Login Success")
     func testUserLoginSuccess() async throws {
         try await withApp(configure: configure) { app in
-            // Create user in this app instance
             try await createUser(in: app)
 
-            // Now test login with the same app instance
+            guard let createdUser = try await User.query(on: app.db)
+                .filter(\.$username == "testuser")
+                .first(),
+                  let expectedUserId = createdUser.id else {
+                throw TestError.userCreationFailed
+            }
+
             let loginCredentials = User(username: "testuser", password: "password")
             try await app.testing().test(.POST, "/api/login") { req in
                 try req.content.encode(loginCredentials)
             } afterResponse: { res in
                 #expect(res.status == .ok)
-
                 let response = try res.content.decode(AuthResponseDTO.self)
                 #expect(!response.token.isEmpty)
                 #expect(!response.refreshToken.isEmpty)
-                #expect(response.userId != UUID())
+                #expect(response.userId == expectedUserId)
             }
         }
     }

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerLoginTests.swift
@@ -37,10 +37,10 @@ struct GrowBitAppServerLoginTests {
             } afterResponse: { res in
                 #expect(res.status == .ok)
 
-                let response = try res.content.decode(LoginResponseDTO.self)
-                #expect(response.error == false)
-                #expect(response.token != nil)
-                #expect(response.reason == nil) // Should be nil on success
+                let response = try res.content.decode(AuthResponseDTO.self)
+                #expect(!response.token.isEmpty)
+                #expect(!response.refreshToken.isEmpty)
+                #expect(response.userId != UUID())
             }
         }
     }

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerLogoutTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerLogoutTests.swift
@@ -1,0 +1,131 @@
+//
+//  GrowBitAppServerLogoutTests.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+@testable import GrowBitAppServer
+import GrowBitSharedDTO
+import VaporTesting
+import Testing
+
+@Suite("Logout Tests")
+struct GrowBitAppServerLogoutTests {
+
+    private func createAndLoginUser(in app: Application, username: String) async throws -> (accessToken: String, refreshToken: String) {
+        let user = User(username: username, password: "password")
+        try await app.testing().test(.POST, "/api/register") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+        }
+
+        var accessToken = ""
+        var refreshToken = ""
+
+        try await app.testing().test(.POST, "/api/login") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+            let response = try res.content.decode(AuthResponseDTO.self)
+            accessToken = response.token
+            refreshToken = response.refreshToken
+        }
+
+        return (accessToken, refreshToken)
+    }
+
+    @Test("Logout success - refresh token is revoked")
+    func logoutRevokesRefreshToken() async throws {
+        try await withApp(configure: configure) { app in
+            let (_, refreshToken) = try await createAndLoginUser(in: app, username: "logoutuser1")
+
+            try await app.testing().test(.POST, "/api/logout") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+
+            // Revoked token should no longer work for refresh
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
+    @Test("Logout with unknown token returns 200 (idempotent)")
+    func logoutUnknownTokenIsIdempotent() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.POST, "/api/logout") { req in
+                try req.content.encode(["refreshToken": "totally-fake-token"])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test("Double logout is idempotent")
+    func doubleLogoutIsIdempotent() async throws {
+        try await withApp(configure: configure) { app in
+            let (_, refreshToken) = try await createAndLoginUser(in: app, username: "logoutuser2")
+
+            try await app.testing().test(.POST, "/api/logout") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+
+            try await app.testing().test(.POST, "/api/logout") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test("Logout one session, other session still works")
+    func logoutOneSessionKeepsOtherAlive() async throws {
+        try await withApp(configure: configure) { app in
+            let user = User(username: "logoutuser3", password: "password")
+            try await app.testing().test(.POST, "/api/register") { req in
+                try req.content.encode(user)
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+
+            // First login
+            var refreshToken1 = ""
+            try await app.testing().test(.POST, "/api/login") { req in
+                try req.content.encode(user)
+            } afterResponse: { res in
+                let response = try res.content.decode(AuthResponseDTO.self)
+                refreshToken1 = response.refreshToken
+            }
+
+            // Second login
+            var refreshToken2 = ""
+            try await app.testing().test(.POST, "/api/login") { req in
+                try req.content.encode(user)
+            } afterResponse: { res in
+                let response = try res.content.decode(AuthResponseDTO.self)
+                refreshToken2 = response.refreshToken
+            }
+
+            // Logout first session
+            try await app.testing().test(.POST, "/api/logout") { req in
+                try req.content.encode(["refreshToken": refreshToken1])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+
+            // Second session should still be valid
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": refreshToken2])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+}

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerRefreshTokenTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerRefreshTokenTests.swift
@@ -1,0 +1,101 @@
+//
+//  GrowBitAppServerRefreshTokenTests.swift
+//  GrowBitAppServer
+//
+
+import Foundation
+@testable import GrowBitAppServer
+import GrowBitSharedDTO
+import VaporTesting
+import Testing
+import Fluent
+
+@Suite("Refresh Token Tests")
+struct GrowBitAppServerRefreshTokenTests {
+
+    private func createAndLoginUser(in app: Application, username: String = "refreshuser") async throws -> (accessToken: String, refreshToken: String, userId: UUID) {
+        let user = User(username: username, password: "password")
+        try await app.testing().test(.POST, "/api/register") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+        }
+
+        var accessToken = ""
+        var refreshToken = ""
+        var userId = UUID()
+
+        try await app.testing().test(.POST, "/api/login") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+            let response = try res.content.decode(AuthResponseDTO.self)
+            accessToken = response.token
+            refreshToken = response.refreshToken
+            userId = response.userId
+        }
+
+        return (accessToken, refreshToken, userId)
+    }
+
+    @Test("Login returns both access token and refresh token")
+    func loginReturnsBothTokens() async throws {
+        try await withApp(configure: configure) { app in
+            let (accessToken, refreshToken, _) = try await createAndLoginUser(in: app)
+            #expect(!accessToken.isEmpty)
+            #expect(!refreshToken.isEmpty)
+        }
+    }
+
+    @Test("Refresh success - returns new access token")
+    func refreshSuccess() async throws {
+        try await withApp(configure: configure) { app in
+            let (originalToken, refreshToken, _) = try await createAndLoginUser(in: app)
+
+            var newAccessToken = ""
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .ok)
+                let response = try res.content.decode(RefreshResponseDTO.self)
+                #expect(!response.token.isEmpty)
+                newAccessToken = response.token
+            }
+
+            #expect(newAccessToken != originalToken)
+        }
+    }
+
+    @Test("Refresh fails with invalid token")
+    func refreshFailsInvalidToken() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": "not-a-real-token"])
+            } afterResponse: { res in
+                #expect(res.status == .unauthorized)
+                #expect(res.body.string.contains("Invalid refresh token"))
+            }
+        }
+    }
+
+    @Test("Refresh fails with expired token")
+    func refreshFailsExpiredToken() async throws {
+        try await withApp(configure: configure) { app in
+            let (_, _, userId) = try await createAndLoginUser(in: app)
+
+            // Insert an already-expired refresh token directly into the DB
+            let expiredToken = RefreshToken(
+                userId: userId,
+                expiresAt: Date().addingTimeInterval(-60)
+            )
+            try await expiredToken.save(on: app.db)
+
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": expiredToken.token])
+            } afterResponse: { res in
+                #expect(res.status == .unauthorized)
+                #expect(res.body.string.contains("expired"))
+            }
+        }
+    }
+}

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerRefreshTokenTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerRefreshTokenTests.swift
@@ -47,22 +47,33 @@ struct GrowBitAppServerRefreshTokenTests {
         }
     }
 
-    @Test("Refresh success - returns new access token")
+    @Test("Refresh success - returns new access and refresh tokens, old refresh token is revoked")
     func refreshSuccess() async throws {
         try await withApp(configure: configure) { app in
             let (originalToken, refreshToken, _) = try await createAndLoginUser(in: app)
 
             var newAccessToken = ""
+            var newRefreshToken = ""
             try await app.testing().test(.POST, "/api/refresh") { req in
                 try req.content.encode(["refreshToken": refreshToken])
             } afterResponse: { res in
                 #expect(res.status == .ok)
                 let response = try res.content.decode(RefreshResponseDTO.self)
                 #expect(!response.token.isEmpty)
+                #expect(!response.refreshToken.isEmpty)
                 newAccessToken = response.token
+                newRefreshToken = response.refreshToken
             }
 
             #expect(newAccessToken != originalToken)
+            #expect(newRefreshToken != refreshToken)
+
+            // Old refresh token must be revoked after rotation
+            try await app.testing().test(.POST, "/api/refresh") { req in
+                try req.content.encode(["refreshToken": refreshToken])
+            } afterResponse: { res in
+                #expect(res.status == .unauthorized)
+            }
         }
     }
 
@@ -91,7 +102,7 @@ struct GrowBitAppServerRefreshTokenTests {
             try await expiredToken.save(on: app.db)
 
             try await app.testing().test(.POST, "/api/refresh") { req in
-                try req.content.encode(["refreshToken": expiredToken.token])
+                try req.content.encode(["refreshToken": expiredToken.rawToken])
             } afterResponse: { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.body.string.contains("expired"))

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
@@ -14,26 +14,6 @@ import Fluent
 @Suite("Category Creation Tests")
 struct GrowBitAppServerSavingCategoryTests {
 
-    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
-        let user = User(username: username, password: "password")
-        try await app.testing().test(.POST, "/api/register") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            #expect(res.status == .ok)
-        }
-
-        var token = ""
-        var userId = UUID()
-        try await app.testing().test(.POST, "/api/login") { req in
-            try req.content.encode(user)
-        } afterResponse: { res in
-            let response = try res.content.decode(AuthResponseDTO.self)
-            token = response.token
-            userId = response.userId
-        }
-        return (token, userId)
-    }
-
     @Test("Category creation - Success")
     func categoryCreationSuccess() async throws {
         try await withApp(configure: configure) { app in
@@ -190,6 +170,3 @@ struct GrowBitAppServerSavingCategoryTests {
     }
 }
 
-enum TestError: Error {
-    case userCreationFailed
-}

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
@@ -129,6 +129,22 @@ struct GrowBitAppServerSavingCategoryTests {
         }
     }
 
+    @Test("Category creation - Fail - Cross-user access returns 403")
+    func categoryCreationCrossUserForbidden() async throws {
+        try await withApp(configure: configure) { app in
+            let (tokenA, _)  = try await registerAndLogin(in: app, username: "postxuser_a")
+            let (_, userBId) = try await registerAndLogin(in: app, username: "postxuser_b")
+
+            let requestBody = ["name": "test category", "colorCode": "#FFFFFF"]
+            try await app.testing().test(.POST, "/api/\(userBId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: tokenA)
+                try req.content.encode(requestBody)
+            } afterResponse: { res in
+                #expect(res.status == .forbidden)
+            }
+        }
+    }
+
     @Test("Category creation - Fail - No auth token")
     func categoryCreationFailNoToken() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
@@ -14,34 +14,34 @@ import Fluent
 @Suite("Category Creation Tests")
 struct GrowBitAppServerSavingCategoryTests {
 
+    private func registerAndLogin(in app: Application, username: String) async throws -> (token: String, userId: UUID) {
+        let user = User(username: username, password: "password")
+        try await app.testing().test(.POST, "/api/register") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            #expect(res.status == .ok)
+        }
+
+        var token = ""
+        var userId = UUID()
+        try await app.testing().test(.POST, "/api/login") { req in
+            try req.content.encode(user)
+        } afterResponse: { res in
+            let response = try res.content.decode(AuthResponseDTO.self)
+            token = response.token
+            userId = response.userId
+        }
+        return (token, userId)
+    }
+
     @Test("Category creation - Success")
     func categoryCreationSuccess() async throws {
         try await withApp(configure: configure) { app in
-            // First create a user using the same pattern as other tests
-            let userRequestBody = User(username: "testuser", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-                let response = try res.content.decode(RegisterResponseDTO.self)
-                #expect(response.error == false)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser")
 
-            // Retrieve the created user from the database
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Create a simple request object with just name and colorCode (no id or userId)
-            let requestBody = [
-                "name": "test category",
-                "colorCode": "#FFFFFF"
-            ]
-
+            let requestBody = ["name": "test category", "colorCode": "#FFFFFF"]
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .ok)
@@ -55,27 +55,11 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Fail - Missing name")
     func categoryCreationFailMissingName() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser2", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser2")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser2")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Request body missing name
-            let requestBody = [
-                "colorCode": "#FFFFFF"
-            ]
-
+            let requestBody = ["colorCode": "#FFFFFF"]
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
@@ -87,27 +71,11 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Fail - Missing colorCode")
     func categoryCreationFailMissingColorCode() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser3", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser3")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser3")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Request body missing colorCode
-            let requestBody = [
-                "name": "test category"
-            ]
-
+            let requestBody = ["name": "test category"]
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
@@ -119,12 +87,11 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Fail - Invalid userId")
     func categoryCreationFailInvalidUserId() async throws {
         try await withApp(configure: configure) { app in
-            let requestBody = [
-                "name": "test category",
-                "colorCode": "#FFFFFF"
-            ]
+            let (token, _) = try await registerAndLogin(in: app, username: "testuser_invalidid")
 
+            let requestBody = ["name": "test category", "colorCode": "#FFFFFF"]
             try await app.testing().test(.POST, "/api/invalid-uuid/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
@@ -135,28 +102,11 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Fail - Empty name")
     func categoryCreationFailEmptyName() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser4", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser4")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser4")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Request body with empty name
-            let requestBody = [
-                "name": "",
-                "colorCode": "#FFFFFF"
-            ]
-
+            let requestBody = ["name": "", "colorCode": "#FFFFFF"]
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
@@ -167,28 +117,11 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Fail - Invalid color code format")
     func categoryCreationFailInvalidColorCode() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser5", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser5")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser5")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Request body with invalid color code (missing #)
-            let requestBody = [
-                "name": "test category",
-                "colorCode": "FF$FF§FF"
-            ]
-
+            let requestBody = ["name": "test category", "colorCode": "FF$FF§FF"]
             try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                req.headers.bearerAuthorization = BearerAuthorization(token: token)
                 try req.content.encode(requestBody)
             } afterResponse: { res in
                 #expect(res.status == .badRequest)
@@ -199,31 +132,13 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Success - Valid color codes")
     func categoryCreationSuccessVariousColors() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser6", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser6")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser6")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Test various valid color codes with #
             let validColors = ["#000000", "#FFFFFF", "#FF0000", "#00FF00", "#0000FF", "#abcdef", "#123456"]
-
             for (index, color) in validColors.enumerated() {
-                let requestBody = [
-                    "name": "category \(index)",
-                    "colorCode": color
-                ]
-
+                let requestBody = ["name": "category \(index)", "colorCode": color]
                 try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                     try req.content.encode(requestBody)
                 } afterResponse: { res in
                     #expect(res.status == .ok)
@@ -237,22 +152,8 @@ struct GrowBitAppServerSavingCategoryTests {
     @Test("Category creation - Success - Color normalization")
     func categoryCreationSuccessColorNormalization() async throws {
         try await withApp(configure: configure) { app in
-            // Create a user
-            let userRequestBody = User(username: "testuser7", password: "password")
-            try await app.testing().test(.POST, "/api/register") { req in
-                try req.content.encode(userRequestBody)
-            } afterResponse: { res in
-                #expect(res.status == .ok)
-            }
+            let (token, userId) = try await registerAndLogin(in: app, username: "testuser7")
 
-            guard let createdUser = try await User.query(on: app.db)
-                .filter(\.$username == "testuser7")
-                .first(),
-                  let userId = createdUser.id else {
-                throw TestError.userCreationFailed
-            }
-
-            // Test that colors without # are normalized to include #
             let testCases: [(input: String, expected: String)] = [
                 ("FF0000", "#FF0000"),
                 ("00FF00", "#00FF00"),
@@ -260,14 +161,10 @@ struct GrowBitAppServerSavingCategoryTests {
                 ("abcdef", "#ABCDEF"),
                 ("123456", "#123456")
             ]
-
             for (index, testCase) in testCases.enumerated() {
-                let requestBody = [
-                    "name": "normalized category \(index)",
-                    "colorCode": testCase.input
-                ]
-
+                let requestBody = ["name": "normalized category \(index)", "colorCode": testCase.input]
                 try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                    req.headers.bearerAuthorization = BearerAuthorization(token: token)
                     try req.content.encode(requestBody)
                 } afterResponse: { res in
                     #expect(res.status == .ok)

--- a/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
+++ b/Tests/GrowBitAppServerTests/GrowBitAppServerSavingCategoryTests.swift
@@ -149,6 +149,20 @@ struct GrowBitAppServerSavingCategoryTests {
         }
     }
 
+    @Test("Category creation - Fail - No auth token")
+    func categoryCreationFailNoToken() async throws {
+        try await withApp(configure: configure) { app in
+            let (_, userId) = try await registerAndLogin(in: app, username: "noauthuser")
+            let requestBody = ["name": "test", "colorCode": "#FFFFFF"]
+            try await app.testing().test(.POST, "/api/\(userId.uuidString)/categories") { req in
+                try req.content.encode(requestBody)
+                // no Bearer token
+            } afterResponse: { res in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
     @Test("Category creation - Success - Color normalization")
     func categoryCreationSuccessColorNormalization() async throws {
         try await withApp(configure: configure) { app in

--- a/Tests/GrowBitAppServerTests/TestHelpers.swift
+++ b/Tests/GrowBitAppServerTests/TestHelpers.swift
@@ -20,6 +20,7 @@ func registerAndLogin(in app: Application, username: String, password: String = 
     try await app.testing().test(.POST, "/api/login") { req in
         try req.content.encode(user)
     } afterResponse: { res in
+        #expect(res.status == .ok)
         let response = try res.content.decode(AuthResponseDTO.self)
         token = response.token
         userId = response.userId

--- a/Tests/GrowBitAppServerTests/TestHelpers.swift
+++ b/Tests/GrowBitAppServerTests/TestHelpers.swift
@@ -3,6 +3,7 @@
 //  GrowBitAppServer
 //
 
+import Foundation
 @testable import GrowBitAppServer
 import VaporTesting
 import Testing

--- a/Tests/GrowBitAppServerTests/TestHelpers.swift
+++ b/Tests/GrowBitAppServerTests/TestHelpers.swift
@@ -1,0 +1,32 @@
+//
+//  TestHelpers.swift
+//  GrowBitAppServer
+//
+
+@testable import GrowBitAppServer
+import VaporTesting
+import Testing
+
+func registerAndLogin(in app: Application, username: String, password: String = "password") async throws -> (token: String, userId: UUID) {
+    let user = User(username: username, password: password)
+    try await app.testing().test(.POST, "/api/register") { req in
+        try req.content.encode(user)
+    } afterResponse: { res in
+        #expect(res.status == .ok)
+    }
+
+    var token = ""
+    var userId = UUID()
+    try await app.testing().test(.POST, "/api/login") { req in
+        try req.content.encode(user)
+    } afterResponse: { res in
+        let response = try res.content.decode(AuthResponseDTO.self)
+        token = response.token
+        userId = response.userId
+    }
+    return (token, userId)
+}
+
+enum TestError: Error {
+    case userCreationFailed
+}


### PR DESCRIPTION
## Summary
  - Adds `POST /api/refresh` — validates a DB-stored refresh token and issues a new 15-minute access token
  - Adds `POST /api/logout` — revokes the refresh token (idempotent, returns 200 for unknown tokens)
  - Login now returns both an access token (15 min) and a refresh token (7 days) via `AuthResponseDTO`
  - Category routes are now JWT-protected via `JWTAuthMiddleware`, which also blocks cross-user access

## Test plan

  - [x] All 36 tests pass (`swift test`)
  - [x] Refresh success returns a new, different access token
  - [x] Refresh with invalid or expired token returns 401
  - [x] Logout revokes the token — subsequent refresh with the same token returns 401
  - [x] Double logout returns 200 (idempotent)
  - [x] Logging out one session leaves other sessions active
  - [x] Category endpoints return 401 without a Bearer token